### PR TITLE
Fix headless mode detection for Jenkins

### DIFF
--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -140,8 +140,8 @@ class BaseTest:
             self.user_data_dir = self._get_unique_user_data_dir()
             chrome_options.add_argument(f'--user-data-dir={self.user_data_dir}')
             
-            # Add headless mode in GitHub Actions
-            if os.environ.get('GITHUB_ACTIONS') == 'true':
+            # Enable headless mode when configured or when running in CI
+            if Config.HEADLESS or os.environ.get('GITHUB_ACTIONS') == 'true':
                 chrome_options.add_argument('--headless')
             
             # Get appropriate ChromeDriver path

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -141,7 +141,12 @@ class BaseTest:
             chrome_options.add_argument(f'--user-data-dir={self.user_data_dir}')
             
             # Enable headless mode when configured or when running in CI
-            if Config.HEADLESS or os.environ.get('GITHUB_ACTIONS') == 'true':
+            if (
+                Config.HEADLESS
+                or os.environ.get('GITHUB_ACTIONS') == 'true'
+                or os.environ.get('CI') == 'true'
+                or os.environ.get('JENKINS_HOME')
+            ):
                 chrome_options.add_argument('--headless')
             
             # Get appropriate ChromeDriver path


### PR DESCRIPTION
## Summary
- respect `Config.HEADLESS` when configuring the driver

## Testing
- `pytest -k test_valid_login -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68519445bf808326b9638997dd929715