### PR TITLE
Fix headless mode detection for Jenkins

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -60,8 +60,15 @@ class Config:
     REPORT_DIR = config.report_dir
     ALLURE_RESULTS_DIR = config.allure_results_dir
     BROWSER = config.browser
-    HEADLESS = config.headless
-    CI_MODE = config.ci_mode
+    # Allow HEADLESS override via environment variable
+    HEADLESS = os.getenv("HEADLESS", str(config.headless)).lower() in ("1", "true", "yes")
+    # Determine CI mode via config or common CI environment variables
+    CI_MODE = (
+        config.ci_mode
+        or os.getenv("CI", "").lower() in ("1", "true", "yes")
+        or bool(os.getenv("JENKINS_HOME"))
+        or bool(os.getenv("JENKINS_URL"))
+    )
     
     @classmethod
     def is_ci_mode(cls) -> bool:

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -140,9 +140,16 @@ class BaseTest:
             self.user_data_dir = self._get_unique_user_data_dir()
             chrome_options.add_argument(f'--user-data-dir={self.user_data_dir}')
             
-            # Add headless mode in GitHub Actions
-            if os.environ.get('GITHUB_ACTIONS') == 'true':
-                chrome_options.add_argument('--headless')
+            # Enable headless mode when configured or when running in CI
+            if (
+                Config.HEADLESS
+                or os.environ.get('HEADLESS', '').lower() in ('1', 'true', 'yes')
+                or os.environ.get('GITHUB_ACTIONS') == 'true'
+                or os.environ.get('CI') == 'true'
+                or os.environ.get('JENKINS_HOME')
+                or os.environ.get('JENKINS_URL')
+            ):
+                chrome_options.add_argument('--headless=new')
             
             # Get appropriate ChromeDriver path
             driver_path = self._get_chrome_driver_path()

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -186,14 +186,3 @@ class TestLogin(BaseTest):
                 name="logout_successful",
                 attachment_type=allure.attachment_type.PNG
             )
-
-# Update the driver setup code to include the --user-data-dir option
-chrome_options = Options()
-chrome_options.add_argument('--headless')
-chrome_options.add_argument('--no-sandbox')
-chrome_options.add_argument('--disable-dev-shm-usage')
-chrome_options.add_argument('--disable-gpu')
-chrome_options.add_argument('--disable-notifications')
-chrome_options.add_argument('--window-size=1920,1080')
-chrome_options.add_argument('--remote-debugging-port=0')
-# Removed the --user-data-dir option for CI stability 

--- a/utils/driver_manager.py
+++ b/utils/driver_manager.py
@@ -184,7 +184,7 @@ class DriverManager:
             
             # Add headless mode if enabled in config
             if options.get("headless"):
-                chrome_options.add_argument('--headless')
+                chrome_options.add_argument('--headless=new')
                 chrome_options.add_argument('--window-size=1920,1080')
                 chrome_options.add_argument('--disable-gpu')
                 chrome_options.add_argument('--no-sandbox')


### PR DESCRIPTION
## Summary
- respect `HEADLESS` environment variable in Config
- add `--headless=new` when running in CI or Jenkins
- clean up stray setup code in login test

## Testing
- `pytest -k test_valid_login -q` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68519445bf808326b9638997dd929715