### PR TITLE
Fix headless mode detection

### DIFF
--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -140,8 +140,8 @@ class BaseTest:
             self.user_data_dir = self._get_unique_user_data_dir()
             chrome_options.add_argument(f'--user-data-dir={self.user_data_dir}')
             
-            # Add headless mode in GitHub Actions
-            if os.environ.get('GITHUB_ACTIONS') == 'true':
+            # Add headless mode if configured or when running in GitHub Actions
+            if Config.HEADLESS or os.environ.get('GITHUB_ACTIONS') == 'true':
                 chrome_options.add_argument('--headless')
             
             # Get appropriate ChromeDriver path


### PR DESCRIPTION
## Summary
- ensure BaseTest uses Config.HEADLESS to activate headless mode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_6852a72b8adc8326a701decbe14f1029